### PR TITLE
Fix bug where  and  are referencing old function name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
 # Release Notes
 
-## [Unreleased](https://github.com/surgiie/console/compare/v0.3.3...master)
+## [Unreleased](https://github.com/surgiie/console/compare/v0.3.4...master)
+
+## [v0.3.4](https://github.com/surgiie/console/compare/v0.3.3...v0.3.4) - 2022-10-23
+### Changed
+
+- Fix bug where `showPerformanceStats` and `getOrAskForInput` are referencing old function name by @surgiie in https://github.com/surgiie/console/pull/5
+## [v0.3.2](https://github.com/surgiie/console/compare/v0.3.0...v0.3.2) - 2022-10-22
 
 ## [v0.3.3](https://github.com/surgiie/console/compare/v0.3.2...v0.3.3) - 2022-10-23
 ### Changed

--- a/src/Command.php
+++ b/src/Command.php
@@ -215,17 +215,17 @@ abstract class Command extends BaseCommand
 
         $message = "Enter $label:";
 
-        $this->lineMessage('INPUT', $message, fg: 'white', bg: 'green');
+        $this->message('INPUT', $message, fg: 'white', bg: 'green');
         $input = $this->$method('ctrl-c to exit');
 
         $validate($input);
 
         if ($confirm) {
-            $this->lineMessage('CONFIRM INPUT', "Confirm $label", fg: 'black', bg: 'cyan');
+            $this->message('CONFIRM INPUT', "Confirm $label", fg: 'black', bg: 'cyan');
             $confirmInput = $this->$method('ctrl-c to exit');
 
             while ($input != $confirmInput) {
-                $this->lineMessage('CONFIRM FAILED', "Try $label confirmation again", fg: 'white', bg: 'red');
+                $this->message('CONFIRM FAILED', "Try $label confirmation again", fg: 'white', bg: 'red');
                 $confirmInput = $this->$method('ctrl-c to exit');
             }
         }
@@ -325,7 +325,7 @@ abstract class Command extends BaseCommand
         // lastly show how we did if specified.
         if ($this->fromPropertyOrMethod('showPerformanceStats', false) !== false) {
             $this->newLine();
-            $this->lineMessage(
+            $this->message(
                 'Peformance',
                 'Memory: '.$this->getMemoryUsage().'|Execution Time: '.number_format($ms, 2, thousands_separator: '').'ms',
                 bg: 'cyan'


### PR DESCRIPTION
Fix bug where functions are referencing old method name.