### PR TITLE
spacing on runTask

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Release Notes
 
-## [Unreleased](https://github.com/surgiie/console/compare/v0.5.1...master)
+## [Unreleased](https://github.com/surgiie/console/compare/v0.5.2...master)
+## [v0.5.2](https://github.com/surgiie/console/compare/v0.5.1...v0.5.2) - 2022-11-05
+### Changed
+- Add extra spacing to finished message for `runTask` to line up better with output from `$this->components` by @surgiie https://github.com/surgiie/console/pull/10
 ## [v0.5.1](https://github.com/surgiie/console/compare/v0.5.0...v0.5.1) - 2022-11-04
 ### Changed
 - Handle array input being used in tests/artisan testing during arbitraryOptions parsing by @surgiie https://github.com/surgiie/console/pull/9

--- a/src/Command.php
+++ b/src/Command.php
@@ -126,7 +126,7 @@ abstract class Command extends BaseCommand
         $task->run();
 
         $this->output->writeln(
-            'Finished - ['.$title.']: '.($task->succeeded() === true ? '<info>✓</info>' : '<error>failed</error>')
+            '  Finished - ['.$title.']: '.($task->succeeded() === true ? '<info>✓</info>' : '<error>failed</error>')
         );
 
         return $task;


### PR DESCRIPTION
Add spacing to run task finish message so it lines up better with output from components.