### PR TITLE
Remove line clear

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## [Unreleased](https://github.com/surgiie/console/compare/v0.5.5...master)
 
-## [v0.5.5](https://github.com/surgiie/console/compare/v0.5.3...v0.5.5) - 2022-11-05
+## [v0.5.5](https://github.com/surgiie/console/compare/v0.5.4...v0.5.5) - 2022-11-05
 
 ### Changed
 - Remove empty line from clear terminal line task, delegate to developer @surgiie https://github.com/surgiie/console/pulls/11

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,11 @@
 # Release Notes
 
-## [Unreleased](https://github.com/surgiie/console/compare/v0.5.4...master)
+## [Unreleased](https://github.com/surgiie/console/compare/v0.5.5...master)
 
+## [v0.5.5](https://github.com/surgiie/console/compare/v0.5.3...v0.5.5) - 2022-11-05
 
+### Changed
+- Remove empty line from clear terminal line task, delegate to developer @surgiie https://github.com/surgiie/console/pulls/11
 ## [v0.5.4](https://github.com/surgiie/console/compare/v0.5.3...v0.5.4) - 2022-11-05
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -265,7 +265,7 @@ $task = $this->runTask("Doing stuff...", function($task){
 
     sleep(4); // simulating stuff.
 
-    // clear terminal line of the loader 
+    // clear terminal line of the loader (escape sequence support required)
     $task->clearTerminalLine();
     // and update output
     // loader will be re-added after this output automatically

--- a/src/Support/Task.php
+++ b/src/Support/Task.php
@@ -73,8 +73,6 @@ abstract class Task
             $this->output->write("\x0D");
             // Erase line.
             $this->output->write("\x1B[2K");
-        } else {
-            $this->output->writeln(''); // Make sure we first close the previous line
         }
     }
 }


### PR DESCRIPTION
Remove empty line clear from `clearTerminalLine` from `Task`. This should be handled by developer if updating output outside of terminal escape sequence support.