### PR TITLE
remove realpath

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,14 @@
 # Release Notes
 
-## [Unreleased](https://github.com/surgiie/console/compare/v0.7.0...master)
+## [Unreleased](https://github.com/surgiie/console/compare/v0.8.0...master)
+
+
+## [v0.8.0](https://github.com/surgiie/console/compare/v0.7.0...v0.8.0) - 2022-11-12
+### Changed
+
+Remove use of `realpath` in `consoleView` for better support for `phar://` file by @surgiie in https://github.com/surgiie/console/pull/16
+Update blade to `v0.4.0` and remove unsused code not removed in previous release. by @surgiie in https://github.com/surgiie/console/pull/15
+
 
 ## [v0.7.0](https://github.com/surgiie/console/compare/v0.6.0...v0.7.0) - 2022-11-11
 ### Changed

--- a/src/Command.php
+++ b/src/Command.php
@@ -96,7 +96,7 @@ abstract class Command extends BaseCommand
         $path = base_path("resources/views/console/$view.php");
 
         if (! is_file($path)) {
-            $path = realpath(__DIR__."/resources/views/$view.php");
+            $path = __DIR__."/resources/views/$view.php";
         }
 
         render((string) $this->compile($path, $data), $verbosity);


### PR DESCRIPTION
Usage of realpath breaks phar builds as the filesystem is virtual and therefore realpath will always return false.
Update change log.