### PR TITLE
fix issue where state file is not present on exceptions

### DIFF
--- a/src/CommandTask.php
+++ b/src/CommandTask.php
@@ -46,9 +46,12 @@ class CommandTask extends Task
 
         $this->succesful = $results[1];
 
-        $this->taskData = unserialize(file_get_contents($stateFile = $this->taskFilePath().'.state'));
+        $stateFile = $this->taskFilePath().'.state';
 
-        unlink($stateFile);
+        if(is_file($stateFile)){
+            $this->taskData = unserialize(file_get_contents($stateFile));
+            unlink($stateFile);
+        }
 
         return $this;
     }


### PR DESCRIPTION
Fix issue where command task state file is not present when trying to clean up when an exception was raised during task.